### PR TITLE
refactor: todo_service.py でDBを削除してGoogle Tasksのみ使用

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,38 +32,36 @@ def echo_prompt(message: str) -> str:
 
 # TODO関連のエンドポイント
 @mcp.tool()
-def add_todo_endpoint(user_id: str, title: str, description: str = None, sync_to_google: bool = True) -> Dict:
-    """TODOアイテムを追加する
+def add_todo_endpoint(user_id: str, title: str, description: str = None) -> Dict:
+    """Google TasksにTODOアイテムを追加する
     
     Args:
         user_id: ユーザーID
         title: TODOのタイトル
         description: TODOの詳細説明（オプション）
-        sync_to_google: GoogleタスクAPIとの同期を行うかどうか
         
     Returns:
         追加されたTODOアイテム
     """
-    return add_todo(user_id, title, description, sync_to_google)
+    return add_todo(user_id, title, description)
 
 
 @mcp.tool()
-def get_all_todos_endpoint(user_id: str, filter_status: str = "all", include_google_tasks: bool = True) -> List[Dict]:
-    """ユーザーの全てのTODOアイテムを取得する
+def get_all_todos_endpoint(user_id: str, filter_status: str = "all") -> List[Dict]:
+    """ユーザーの全てのTODOアイテムをGoogle Tasksから取得する
     
     Args:
         user_id: ユーザーID
         filter_status: フィルターオプション。'completed'または'active'を指定可能
-        include_google_tasks: Google Tasksからのタスクも含めるかどうか
     
     Returns:
         TODOアイテムのリスト
     """
-    return get_all_todos(user_id, filter_status, include_google_tasks)
+    return get_all_todos(user_id, filter_status)
 
 
 @mcp.tool()
-def get_todo_endpoint(user_id: str, todo_id: int) -> Dict:
+def get_todo_endpoint(user_id: str, todo_id: str) -> Dict:
     """指定されたIDのTODOアイテムを取得する
     
     Args:
@@ -77,7 +75,7 @@ def get_todo_endpoint(user_id: str, todo_id: int) -> Dict:
 
 
 @mcp.tool()
-def update_todo_status_endpoint(user_id: str, todo_id: int, completed: bool) -> Dict:
+def update_todo_status_endpoint(user_id: str, todo_id: str, completed: bool) -> Dict:
     """TODOの完了状態を更新する
     
     Args:

--- a/todo_service.py
+++ b/todo_service.py
@@ -1,163 +1,139 @@
 from typing import List, Dict
-from datetime import datetime
-from sqlalchemy.orm import Session
-from models import TodoItem as DBTodoItem, get_db
-from schemas import TodoItem
+from models import get_db
 from google_api import get_google_tasks_service
 
 
-def add_todo(user_id: str, title: str, description: str = None, sync_to_google: bool = True) -> Dict:
-    """TODOアイテムを追加する"""
+def _get_default_tasklist_id(tasks_service) -> str:
+    """デフォルトのタスクリストIDを取得するヘルパー関数"""
+    tasklists = tasks_service.tasklists().list().execute()
+    if tasklists.get('items'):
+        return tasklists['items'][0]['id']
+    raise ValueError("No tasklists found")
+
+
+def _create_task_dict(google_task: Dict, user_id: str) -> Dict:
+    """Google TaskからTODO辞書を作成するヘルパー関数"""
+    return {
+        'id': f"google_{google_task.get('id')}",
+        'user_id': user_id,
+        'title': google_task.get('title', ''),
+        'description': google_task.get('notes', ''),
+        'completed': google_task.get('status') == 'completed',
+        'created_at': google_task.get('updated'),
+        'source': 'google_tasks',
+        'google_task_id': google_task.get('id')
+    }
+
+
+def add_todo(user_id: str, title: str, description: str = None) -> Dict:
+    """Google TasksにTODOアイテムを追加する"""
     # データベースセッションを取得
     db = next(get_db())
     
-    # 新しいTODOアイテムを作成
-    db_todo = DBTodoItem(
-        user_id=user_id,
-        title=title,
-        description=description,
-        created_at=datetime.now()
-    )
-    
-    # データベースに追加して保存
-    db.add(db_todo)
-    db.commit()
-    db.refresh(db_todo)
-    
-    # Google Tasksとの同期を試行
-    google_task_id = None
-    if sync_to_google:
-        try:
-            tasks_service = get_google_tasks_service(user_id, db)
-            if tasks_service:
-                # デフォルトのタスクリストを取得
-                tasklists = tasks_service.tasklists().list().execute()
-                if tasklists.get('items'):
-                    tasklist_id = tasklists['items'][0]['id']
-                    
-                    # Google Tasksにタスクを追加
-                    task_body = {
-                        'title': title,
-                        'notes': description or '',
-                    }
-                    result = tasks_service.tasks().insert(
-                        tasklist=tasklist_id,
-                        body=task_body
-                    ).execute()
-                    google_task_id = result.get('id')
-        except Exception as e:
-            # Google API呼び出しでエラーが発生した場合、ログに記録するが処理は継続
-            print(f"Google Tasks API error: {e}")
-    
-    # Pydanticモデルに変換して返す
-    result = TodoItem.from_orm(db_todo).dict()
-    if google_task_id:
-        result['google_task_id'] = google_task_id
-    return result
+    try:
+        tasks_service = get_google_tasks_service(user_id, db)
+        if tasks_service:
+            tasklist_id = _get_default_tasklist_id(tasks_service)
+            if tasklist_id:
+                # Google Tasksにタスクを追加
+                task_body = {
+                    'title': title,
+                    'notes': description or '',
+                }
+                result = tasks_service.tasks().insert(
+                    tasklist=tasklist_id,
+                    body=task_body
+                ).execute()
+                
+                return _create_task_dict(result, user_id)
+        return {"error": "Google Tasks service not available"}
+    except Exception as e:
+        return {"error": f"Google Tasks API error: {e}"}
 
 
-def get_all_todos(user_id: str, filter_status: str = "all", include_google_tasks: bool = True) -> List[Dict]:
-    """ユーザーの全てのTODOアイテムを取得する"""
+def get_all_todos(user_id: str, filter_status: str = "all") -> List[Dict]:
+    """Google TasksからTODOアイテムを取得する"""
     # データベースセッションを取得
     db = next(get_db())
     
-    # ユーザーのTODOを検索するクエリを作成
-    query = db.query(DBTodoItem).filter(DBTodoItem.user_id == user_id)
+    result = []
     
-    # フィルターステータスに基づいてクエリを絞り込む
-    if filter_status == "completed":
-        query = query.filter(DBTodoItem.completed == True)
-    elif filter_status == "active":
-        query = query.filter(DBTodoItem.completed == False)
-    elif filter_status == "all" or filter_status is None:
-        pass  # フィルタリングなし
-    else:
-        return {"error": f"Invalid filter status: {filter_status}. Use 'all', 'completed', or 'active'."}
-    
-    # クエリを実行してTODOアイテムを取得
-    todos = query.all()
-    result = [TodoItem.from_orm(todo).dict() for todo in todos]
-    
-    # Google Tasksからのタスクも取得
-    if include_google_tasks:
-        try:
-            tasks_service = get_google_tasks_service(user_id, db)
-            if tasks_service:
-                # デフォルトのタスクリストを取得
-                tasklists = tasks_service.tasklists().list().execute()
-                if tasklists.get('items'):
-                    tasklist_id = tasklists['items'][0]['id']
+    try:
+        tasks_service = get_google_tasks_service(user_id, db)
+        if tasks_service:
+            tasklist_id = _get_default_tasklist_id(tasks_service)
+            if tasklist_id:
+                # Google Tasksからタスクを取得
+                google_tasks = tasks_service.tasks().list(tasklist=tasklist_id).execute()
+                
+                for google_task in google_tasks.get('items', []):
+                    # フィルターステータスに応じてGoogle Tasksをフィルタリング
+                    is_completed = google_task.get('status') == 'completed'
                     
-                    # Google Tasksからタスクを取得
-                    google_tasks = tasks_service.tasks().list(tasklist=tasklist_id).execute()
+                    if filter_status == "completed" and not is_completed:
+                        continue
+                    elif filter_status == "active" and is_completed:
+                        continue
                     
-                    for google_task in google_tasks.get('items', []):
-                        # フィルターステータスに応じてGoogle Tasksをフィルタリング
-                        is_completed = google_task.get('status') == 'completed'
-                        
-                        if filter_status == "completed" and not is_completed:
-                            continue
-                        elif filter_status == "active" and is_completed:
-                            continue
-                        
-                        # Google Taskを結果に追加
-                        result.append({
-                            'id': f"google_{google_task.get('id')}",
-                            'user_id': user_id,
-                            'title': google_task.get('title', ''),
-                            'description': google_task.get('notes', ''),
-                            'completed': is_completed,
-                            'created_at': google_task.get('updated'),
-                            'source': 'google_tasks',
-                            'google_task_id': google_task.get('id')
-                        })
-        except Exception as e:
-            # Google API呼び出しでエラーが発生した場合、ログに記録するが処理は継続
-            print(f"Google Tasks API error: {e}")
+                    # Google Taskを結果に追加
+                    result.append(_create_task_dict(google_task, user_id))
+    except Exception as e:
+        # Google API呼び出しでエラーが発生した場合、ログに記録するが処理は継続
+        print(f"Google Tasks API error: {e}")
     
     return result
 
 
-def get_todo(user_id: str, todo_id: int) -> Dict:
-    """指定されたIDのTODOアイテムを取得する"""
+def get_todo(user_id: str, todo_id: str) -> Dict:
+    """指定されたIDのTODOアイテムをGoogle Tasksから取得する"""
     # データベースセッションを取得
     db = next(get_db())
     
-    # 指定されたIDのTODOを取得
-    todo = db.query(DBTodoItem).filter(DBTodoItem.id == todo_id).first()
+    # Google Task IDを抽出（「google_」プレフィックスを削除）
+    google_task_id = todo_id.replace('google_', '') if todo_id.startswith('google_') else todo_id
     
-    # TODOが存在しない場合
-    if todo is None:
-        return {"error": f"Todo with ID {todo_id} not found"}
-    
-    # ユーザーのTODOかどうかを確認
-    if todo.user_id != user_id:
-        return {"error": f"Todo with ID {todo_id} not found for user {user_id}"}
-    
-    # Pydanticモデルに変換して返す
-    return TodoItem.from_orm(todo).dict()
+    try:
+        tasks_service = get_google_tasks_service(user_id, db)
+        if tasks_service:
+            tasklist_id = _get_default_tasklist_id(tasks_service)
+            if tasklist_id:
+                # 指定されたIDのタスクを取得
+                google_task = tasks_service.tasks().get(
+                    tasklist=tasklist_id,
+                    task=google_task_id
+                ).execute()
+                
+                return _create_task_dict(google_task, user_id)
+        return {"error": "Google Tasks service not available"}
+    except Exception as e:
+        return {"error": f"Todo with ID {todo_id} not found: {e}"}
 
 
-def update_todo_status(user_id: str, todo_id: int, completed: bool) -> Dict:
-    """TODOの完了状態を更新する"""
+def update_todo_status(user_id: str, todo_id: str, completed: bool) -> Dict:
+    """Google TasksでTODOの完了状態を更新する"""
     # データベースセッションを取得
     db = next(get_db())
     
-    # 指定されたIDのTODOを取得
-    todo = db.query(DBTodoItem).filter(DBTodoItem.id == todo_id).first()
+    # Google Task IDを抽出（「google_」プレフィックスを削除）
+    google_task_id = todo_id.replace('google_', '') if todo_id.startswith('google_') else todo_id
     
-    # TODOが存在しない場合
-    if todo is None:
-        return {"error": f"Todo with ID {todo_id} not found"}
-    
-    # ユーザーのTODOかどうかを確認
-    if todo.user_id != user_id:
-        return {"error": f"Todo with ID {todo_id} not found for user {user_id}"}
-    
-    # TODOの完了状態を更新
-    todo.completed = completed
-    db.commit()
-    db.refresh(todo)
-    
-    # Pydanticモデルに変換して返す
-    return TodoItem.from_orm(todo).dict()
+    try:
+        tasks_service = get_google_tasks_service(user_id, db)
+        if tasks_service:
+            tasklist_id = _get_default_tasklist_id(tasks_service)
+            if tasklist_id:
+                # タスクの完了状態を更新
+                task_body = {
+                    'status': 'completed' if completed else 'needsAction'
+                }
+                
+                updated_task = tasks_service.tasks().patch(
+                    tasklist=tasklist_id,
+                    task=google_task_id,
+                    body=task_body
+                ).execute()
+                
+                return _create_task_dict(updated_task, user_id)
+        return {"error": "Google Tasks service not available"}
+    except Exception as e:
+        return {"error": f"Failed to update todo with ID {todo_id}: {e}"}


### PR DESCRIPTION
## Summary
- todo_service.pyからDB関連のコードを削除し、Google Tasks APIのみを使用するよう修正
- ヘルパー関数を追加して重複コードを解消
- 型エラーを修正し、コードの品質を向上

## 主な変更
- ❌ DBTodoItemモデルとSQLAlchemy操作を完全に削除
- ✅ 全ての機能をGoogle Tasks APIベースに変更
- ✅ ヘルパー関数を追加：
  - `_get_default_tasklist_id()`: デフォルトタスクリスト取得
  - `_create_task_dict()`: Google TaskからTODO辞書作成
- ✅ todo_idの型をstrに修正（Google TasksのIDは文字列）
- ✅ 不要なimportを削除（datetime, Session, DBTodoItem, TodoItem）

## Test plan
- [ ] TODO追加機能のテスト
- [ ] TODO一覧取得機能のテスト
- [ ] TODO取得機能のテスト  
- [ ] TODO状態更新機能のテスト
- [ ] Google Tasks認証が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)